### PR TITLE
misc: mark function defs as inline for odr

### DIFF
--- a/echion/coremodule.cc
+++ b/echion/coremodule.cc
@@ -10,7 +10,6 @@
 #endif
 
 #include <condition_variable>
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <mutex>
@@ -18,7 +17,6 @@
 
 #include <fcntl.h>
 #include <sched.h>
-#include <signal.h>
 #include <time.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/echion/greenlets.h
+++ b/echion/greenlets.h
@@ -36,7 +36,7 @@ public:
 
 // ----------------------------------------------------------------------------
 
-int GreenletInfo::unwind(PyObject* frame, PyThreadState* tstate, FrameStack& stack)
+inline int GreenletInfo::unwind(PyObject* frame, PyThreadState* tstate, FrameStack& stack)
 {
     PyObject* frame_addr = NULL;
 #if PY_VERSION_HEX >= 0x030d0000

--- a/echion/memory.h
+++ b/echion/memory.h
@@ -6,7 +6,6 @@
 
 #include <Python.h>
 
-#include <exception>
 #include <optional>
 #include <unordered_map>
 
@@ -48,7 +47,7 @@ private:
     }
 };
 
-ResidentMemoryTracker rss_tracker;
+inline ResidentMemoryTracker rss_tracker;
 
 // ----------------------------------------------------------------------------
 

--- a/echion/mojo.h
+++ b/echion/mojo.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#include <exception>
-#include <ostream>
-
 #define MOJO_VERSION 3
 
 enum MojoEvent

--- a/echion/render.h
+++ b/echion/render.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <fstream>
-#include <functional>
 #include <iostream>
 #include <memory>
 #include <mutex>

--- a/echion/signals.h
+++ b/echion/signals.h
@@ -17,7 +17,7 @@
 inline std::mutex sigprof_handler_lock;
 
 // ----------------------------------------------------------------------------
-void sigprof_handler([[maybe_unused]] int signum)
+inline void sigprof_handler([[maybe_unused]] int signum)
 {
 #ifndef UNWIND_NATIVE_DISABLE
     unwind_native_stack();
@@ -29,7 +29,7 @@ void sigprof_handler([[maybe_unused]] int signum)
 }
 
 // ----------------------------------------------------------------------------
-void sigquit_handler([[maybe_unused]] int signum)
+inline void sigquit_handler([[maybe_unused]] int signum)
 {
     // Wake up the where thread
     std::lock_guard<std::mutex> lock(where_lock);
@@ -37,7 +37,7 @@ void sigquit_handler([[maybe_unused]] int signum)
 }
 
 // ----------------------------------------------------------------------------
-void install_signals()
+inline void install_signals()
 {
     signal(SIGQUIT, sigquit_handler);
 
@@ -46,7 +46,7 @@ void install_signals()
 }
 
 // ----------------------------------------------------------------------------
-void restore_signals()
+inline void restore_signals()
 {
     signal(SIGQUIT, SIG_DFL);
 

--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -84,7 +84,7 @@ inline FrameStack interleaved_stack;
 
 // ----------------------------------------------------------------------------
 #ifndef UNWIND_NATIVE_DISABLE
-void unwind_native_stack()
+inline void unwind_native_stack()
 {
     unw_cursor_t cursor;
     unw_context_t context;

--- a/echion/tasks.h
+++ b/echion/tasks.h
@@ -62,7 +62,7 @@ public:
     GenInfo(PyObject* gen_addr);
 };
 
-GenInfo::GenInfo(PyObject* gen_addr)
+inline GenInfo::GenInfo(PyObject* gen_addr)
 {
     PyGenObject gen;
 
@@ -152,7 +152,7 @@ inline std::unordered_map<PyObject*, PyObject*> task_link_map;
 inline std::mutex task_link_map_lock;
 
 // ----------------------------------------------------------------------------
-TaskInfo::TaskInfo(TaskObj* task_addr)
+inline TaskInfo::TaskInfo(TaskObj* task_addr)
 {
     TaskObj task;
     if (copy_type(task_addr, task))
@@ -195,7 +195,7 @@ TaskInfo::TaskInfo(TaskObj* task_addr)
 }
 
 // ----------------------------------------------------------------------------
-TaskInfo TaskInfo::current(PyObject* loop)
+inline TaskInfo TaskInfo::current(PyObject* loop)
 {
     if (loop == NULL)
         throw Error();
@@ -217,7 +217,7 @@ TaskInfo TaskInfo::current(PyObject* loop)
 
 // ----------------------------------------------------------------------------
 // TODO: Make this a "for_each_task" function?
-std::vector<TaskInfo::Ptr> get_all_tasks(PyObject* loop)
+inline std::vector<TaskInfo::Ptr> get_all_tasks(PyObject* loop)
 {
     std::vector<TaskInfo::Ptr> tasks;
     if (loop == NULL)

--- a/echion/threads.h
+++ b/echion/threads.h
@@ -12,7 +12,6 @@
 #include <exception>
 #include <functional>
 #include <mutex>
-#include <sstream>
 #include <unordered_map>
 
 #if defined PL_LINUX
@@ -94,7 +93,7 @@ private:
     void unwind_greenlets(PyThreadState*, unsigned long);
 };
 
-void ThreadInfo::update_cpu_time()
+inline void ThreadInfo::update_cpu_time()
 {
 #if defined PL_LINUX
     struct timespec ts;
@@ -118,7 +117,7 @@ void ThreadInfo::update_cpu_time()
 #endif
 }
 
-bool ThreadInfo::is_running()
+inline bool ThreadInfo::is_running()
 {
 #if defined PL_LINUX
     struct timespec ts1, ts2;
@@ -157,7 +156,7 @@ inline std::unordered_map<uintptr_t, ThreadInfo::Ptr>& thread_info_map =
 inline std::mutex thread_info_map_lock;
 
 // ----------------------------------------------------------------------------
-void ThreadInfo::unwind(PyThreadState* tstate)
+inline void ThreadInfo::unwind(PyThreadState* tstate)
 {
     if (native)
     {
@@ -200,7 +199,7 @@ void ThreadInfo::unwind(PyThreadState* tstate)
 }
 
 // ----------------------------------------------------------------------------
-void ThreadInfo::unwind_tasks()
+inline void ThreadInfo::unwind_tasks()
 {
     std::vector<TaskInfo::Ref> leaf_tasks;
     std::unordered_set<PyObject*> parent_tasks;
@@ -322,7 +321,7 @@ void ThreadInfo::unwind_tasks()
 }
 
 // ----------------------------------------------------------------------------
-void ThreadInfo::unwind_greenlets(PyThreadState* tstate, unsigned long native_id)
+inline void ThreadInfo::unwind_greenlets(PyThreadState* tstate, unsigned long native_id)
 {
     const std::lock_guard<std::mutex> guard(greenlet_info_map_lock);
 
@@ -395,7 +394,7 @@ void ThreadInfo::unwind_greenlets(PyThreadState* tstate, unsigned long native_id
 }
 
 // ----------------------------------------------------------------------------
-void ThreadInfo::sample(int64_t iid, PyThreadState* tstate, microsecond_t delta)
+inline void ThreadInfo::sample(int64_t iid, PyThreadState* tstate, microsecond_t delta)
 {
     Renderer::get().render_thread_begin(tstate, name, delta, thread_id, native_id);
 

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -18,7 +19,6 @@
 #include <sys/uio.h>
 #include <unistd.h>
 #include <algorithm>
-#include <memory>
 
 typedef pid_t proc_ref_t;
 
@@ -167,7 +167,7 @@ public:
         }
 
         // Copy the data from the buffer to the remote process
-        memcpy(local_iov[0].iov_base, buffer, local_iov[0].iov_len);
+        std::memcpy(local_iov[0].iov_base, buffer, local_iov[0].iov_len);
         return ret;
     }
 


### PR DESCRIPTION
## What does this PR do?

This PR 
- Marks all relevant function/method definitions as `inline` to avoid getting warnings about potential ODR violations
  - Defining symbols (functions/methods but also variables) in header files can be problematic if a header file is included in more than a single translation unit, as it would lead to symbols being defined more than once and fail linking
  - In Echion, we only have on `.cc` file, so this isn't a problem in practice
  - However, this gives me warnings as it could in theory be a problem
  - Marking those definitions as `inline` tells the compiler to trust us, and makes it so that the linker will merge definitions as long as they are identical.
- Removes unused `#include`'s