### PR TITLE
perf: use stack-allocated objects for FrameStack

### DIFF
--- a/echion/memory.h
+++ b/echion/memory.h
@@ -203,7 +203,7 @@ inline auto& memory_table = *(new MemoryTable());
 // ----------------------------------------------------------------------------
 static inline void general_alloc(void* address, size_t size)
 {
-    auto stack = std::make_unique<FrameStack>();
+    auto stack = FrameStack();
     auto* tstate = PyThreadState_Get();  // DEV: This should be called with the GIL held
 
     // DEV: We unwind the stack by reading the data out of live Python objects.
@@ -212,7 +212,7 @@ static inline void general_alloc(void* address, size_t size)
     // Therefore, we expect these structures to remain valid and essentially
     // immutable for the duration of the unwinding process, which happens
     // in-line with the allocation within the calling thread.
-    unwind_python_stack_unsafe(tstate, *stack);
+    unwind_python_stack_unsafe(tstate, stack);
 
     // Store the stack and get its key for reference
     // TODO: Handle collision exception

--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -41,7 +41,7 @@ public:
     }
 
     // ------------------------------------------------------------------------
-    void render()
+    void render() const
     {
         for (auto it = this->rbegin(); it != this->rend(); ++it)
         {
@@ -55,7 +55,7 @@ public:
     }
 
     // ------------------------------------------------------------------------
-    void render_where()
+    void render_where() const
     {
         for (auto it = this->rbegin(); it != this->rend(); ++it)
         {
@@ -337,11 +337,11 @@ class StackTable
 {
 public:
     // ------------------------------------------------------------------------
-    FrameStack::Key inline store(FrameStack::Ptr stack)
+    FrameStack::Key inline store(FrameStack&& stack)
     {
         std::lock_guard<std::mutex> lock(this->lock);
 
-        auto stack_key = stack->key();
+        auto stack_key = stack.key();
 
         auto stack_entry = table.find(stack_key);
         if (stack_entry == table.end())
@@ -357,11 +357,11 @@ public:
     }
 
     // ------------------------------------------------------------------------
-    FrameStack& retrieve(FrameStack::Key stack_key)
+    const FrameStack& retrieve(FrameStack::Key stack_key)
     {
         std::lock_guard<std::mutex> lock(this->lock);
 
-        return *table.find(stack_key)->second;
+        return table.find(stack_key)->second;
     }
 
     // ------------------------------------------------------------------------
@@ -373,7 +373,7 @@ public:
     }
 
 private:
-    std::unordered_map<FrameStack::Key, std::unique_ptr<FrameStack>> table;
+    std::unordered_map<FrameStack::Key, FrameStack> table;
     std::mutex lock;
 };
 


### PR DESCRIPTION
# TODO

Will  not merge this as this is memory-related and we're not using memory profiler.