### PR TITLE
fix: work around race conditions for on-CPU Tasks

### DIFF
--- a/echion/coremodule.cc
+++ b/echion/coremodule.cc
@@ -54,7 +54,7 @@ static void do_where(std::ostream& stream)
                 auto interleave_success = interleave_stacks();
                 if (!interleave_success)
                 {
-                    std::cerr << "could not interleave stacks" << std::endl;
+                    // std::cerr <<"could not interleave stacks" << std::endl;
                     return;
                 }
 
@@ -131,7 +131,7 @@ static inline void _start()
             do_where(pipe);
 
         else
-            std::cerr << "Failed to open pipe " << pipe_name << std::endl;
+            // std::cerr <<"Failed to open pipe " << pipe_name << std::endl;
 
         running = 0;
 

--- a/echion/coremodule.cc
+++ b/echion/coremodule.cc
@@ -178,6 +178,7 @@ static inline void _stop()
         const std::lock_guard<std::mutex> guard(thread_info_map_lock);
 
         thread_info_map.clear();
+        string_table.dump(std::cerr);
         string_table.clear();
     }
 

--- a/echion/danger.h
+++ b/echion/danger.h
@@ -64,7 +64,7 @@ public:
 
         void* mem = mmap(nullptr, kAltStackSize, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
         if (mem == MAP_FAILED) {
-            std::cerr << "Failed to allocate alt stack. Memory copying may not work." << " Error: " << strerror(errno) << std::endl;
+            // std::cerr <<"Failed to allocate alt stack. Memory copying may not work." << " Error: " << strerror(errno) << std::endl;
             return -1;
         }
 
@@ -73,7 +73,7 @@ public:
         ss.ss_size = kAltStackSize;
         ss.ss_flags = 0;
         if (sigaltstack(&ss, nullptr) != 0) {
-            std::cerr << "Failed to set alt stack. Memory copying may not work." << " Error: " << strerror(errno) << std::endl;
+            // std::cerr <<"Failed to set alt stack. Memory copying may not work." << " Error: " << strerror(errno) << std::endl;
             return -1;
         }
 

--- a/echion/render.cc
+++ b/echion/render.cc
@@ -7,7 +7,7 @@ void WhereRenderer::render_frame(Frame& frame)
     auto maybe_name_str = string_table.lookup(frame.name);
     if (!maybe_name_str)
     {
-        std::cerr << "could not get name for render_frame" << std::endl;
+        // std::cerr <<"could not get name for render_frame" << std::endl;
         return;
     }
     const auto& name_str = maybe_name_str->get();
@@ -16,7 +16,7 @@ void WhereRenderer::render_frame(Frame& frame)
     auto maybe_filename_str = string_table.lookup(frame.filename);
     if (!maybe_filename_str)
     {
-        std::cerr << "could not get filename for render_frame" << std::endl;
+        // std::cerr <<"could not get filename for render_frame" << std::endl;
         return;
     }
     const auto& filename_str = maybe_filename_str->get();

--- a/echion/render.h
+++ b/echion/render.h
@@ -210,7 +210,7 @@ public:
         output.open(std::getenv("ECHION_OUTPUT"));
         if (!output.is_open())
         {
-            std::cerr << "Failed to open output file " << std::getenv("ECHION_OUTPUT") << std::endl;
+            // std::cerr <<"Failed to open output file " << std::getenv("ECHION_OUTPUT") << std::endl;
             return ErrorKind::RendererError;
         }
 

--- a/echion/stacks.h
+++ b/echion/stacks.h
@@ -281,7 +281,7 @@ static Result<void> interleave_stacks(FrameStack& python_stack)
             {
                 // We expected a Python frame but we found none, so we report
                 // the native frame instead.
-                std::cerr << "Expected Python frame(s), found none!" << std::endl;
+                // std::cerr <<"Expected Python frame(s), found none!" << std::endl;
                 interleaved_stack.push_front(native_frame);
             }
             else
@@ -311,7 +311,7 @@ static Result<void> interleave_stacks(FrameStack& python_stack)
 
     if (p != python_stack.rend())
     {
-        std::cerr << "Python stack not empty after interleaving!" << std::endl;
+        // std::cerr <<"Python stack not empty after interleaving!" << std::endl;
         while (p != python_stack.rend())
             interleaved_stack.push_front(*p++);
     }

--- a/echion/strings.h
+++ b/echion/strings.h
@@ -229,6 +229,15 @@ public:
         this->emplace(UNKNOWN, "<unknown>");
     };
 
+    void dump(std::ostream& os) const
+    {
+        os << "String table:" << std::endl;
+        for (const auto& [key, value] : *this)
+        {
+            os << "  " << key << ": " << value << std::endl;
+        }
+    }
+
 private:
     mutable std::mutex table_lock;
 };

--- a/echion/tasks.h
+++ b/echion/tasks.h
@@ -362,7 +362,7 @@ inline std::vector<std::unique_ptr<StackInfo>> current_tasks;
 
 inline Result<size_t> TaskInfo::unwind(FrameStack& stack, size_t& upper_python_stack_size)
 {
-    std::cerr << "Unwinding the Task" << std::endl;
+    // std::cerr <<"Unwinding the Task" << std::endl;
     // TODO: Check for running task.
     std::stack<PyObject*> coro_frames;
 
@@ -378,16 +378,16 @@ inline Result<size_t> TaskInfo::unwind(FrameStack& stack, size_t& upper_python_s
     size_t count = 0;
 
     // Unwind the coro frames
-    std::cerr << "Unwinding the coroutine frames, we have " << coro_frames.size() << " coro frames" << std::endl;
+    // std::cerr <<"Unwinding the coroutine frames, we have " << coro_frames.size() << " coro frames" << std::endl;
     while (!coro_frames.empty())
     {
         PyObject* frame = coro_frames.top();
         coro_frames.pop();
 
         auto new_frames = unwind_frame(frame, stack);
-        std::cerr << "Unwound " << new_frames << " frames" << (new_frames > 1 ? " more than one" : "") << std::endl;
+        // std::cerr <<"Unwound " << new_frames << " frames" << (new_frames > 1 ? " more than one" : "") << std::endl;
         for (size_t i = 0; i < new_frames; i++) {
-            std::cerr << "  " << i << ": " << string_table.lookup(stack[stack.size() - i - 1].get().name)->get() << std::endl;
+            // std::cerr <<"  " << i << ": " << string_table.lookup(stack[stack.size() - i - 1].get().name)->get() << std::endl;
         }
 
         // If this is the first Frame being unwound (we have not added any Frames to the Stack yet),
@@ -395,19 +395,19 @@ inline Result<size_t> TaskInfo::unwind(FrameStack& stack, size_t& upper_python_s
         if (count == 0) {
             // The first Frame is the coroutine Frame, so the Python stack size is the number of Frames - 1
             upper_python_stack_size = new_frames - 1;
-            std::cerr << "Determining the size of the upper Python stack: " << upper_python_stack_size << std::endl;
+            // std::cerr <<"Determining the size of the upper Python stack: " << upper_python_stack_size << std::endl;
 
             if (this->is_on_cpu && upper_python_stack_size == 0) {
-                std::cerr << "Task is on CPU, but the upper Python stack size is 0. This is not possible." << std::endl;
+                // std::cerr <<"Task is on CPU, but the upper Python stack size is 0. This is not possible." << std::endl;
                 return ErrorKind::TaskInfoError;
             }
 
             // Remove the Python Frames from the Stack (they will be added back later)
             // We cannot push those Frames now because otherwise they would be added once per Task,
             // we only want to add them once per Leaf Task, and on top of all non-leaf Tasks.
-            std::cerr << "Removing " << upper_python_stack_size << " frames from the Stack" << std::endl;
+            // std::cerr <<"Removing " << upper_python_stack_size << " frames from the Stack" << std::endl;
             for (size_t i = 0; i < upper_python_stack_size; i++) {
-                std::cerr << "  - " << string_table.lookup(stack[stack.size() - 1].get().name)->get() << std::endl;
+                // std::cerr <<"  - " << string_table.lookup(stack[stack.size() - 1].get().name)->get() << std::endl;
                 stack.pop_back();
             }
         }

--- a/echion/threads.h
+++ b/echion/threads.h
@@ -235,11 +235,11 @@ inline void ThreadInfo::unwind(PyThreadState* tstate)
 // ----------------------------------------------------------------------------
 inline Result<void> ThreadInfo::unwind_tasks()
 {
-    std::cerr << "===== Unwinding tasks ==" << std::endl;
-    std::cerr << "Python stack:" << std::endl;
+    // std::cerr <<"===== Unwinding tasks ==" << std::endl;
+    // std::cerr <<"Python stack:" << std::endl;
     for (size_t i = 0; i < python_stack.size(); i++)
     {
-        std::cerr << "  " << i << ": " << string_table.lookup(python_stack[i].get().name)->get() << std::endl;
+        // std::cerr <<"  " << i << ": " << string_table.lookup(python_stack[i].get().name)->get() << std::endl;
     }
 
     // Check if the Python stack contains "_run". 
@@ -297,7 +297,7 @@ inline Result<void> ThreadInfo::unwind_tasks()
     }
 
     if (saw_at_least_one_running_task != expect_at_least_one_running_task) {
-        std::cerr << "SKIPSKIP because of inconsistent task state, expected: " << expect_at_least_one_running_task << " saw: " << saw_at_least_one_running_task << " running task: " << running_task_name << std::endl;
+        // std::cerr <<"SKIPSKIP because of inconsistent task state, expected: " << expect_at_least_one_running_task << " saw: " << saw_at_least_one_running_task << " running task: " << running_task_name << std::endl;
         return ErrorKind::TaskInfoError;
     }
 
@@ -338,7 +338,7 @@ inline Result<void> ThreadInfo::unwind_tasks()
             {
                 // This task is not running, so we skip it if we are
                 // interested in just CPU time.
-                std::cerr << "SKIPPING TASK " << string_table.lookup(task->name)->get() << " because it is not on CPU" << std::endl;
+                // std::cerr <<"SKIPPING TASK " << string_table.lookup(task->name)->get() << " because it is not on CPU" << std::endl;
                 continue;
             }
             leaf_tasks.push_back(std::ref(*task));
@@ -350,13 +350,13 @@ inline Result<void> ThreadInfo::unwind_tasks()
         return ((a.get().is_on_cpu ? 0 : 1) < (b.get().is_on_cpu ? 0 : 1));
     });
 
-    std::cerr << "Leaf tasks:" << std::endl;
-    for (const auto& leaf_task : leaf_tasks) {
-        std::cerr << "  " << string_table.lookup(leaf_task.get().name)->get() << " on cpu: " << leaf_task.get().is_on_cpu << std::endl;
-    }
+    // std::cerr <<"Leaf tasks:" << std::endl;
+    // for (const auto& leaf_task : leaf_tasks) {
+        // std::cerr <<"  " << string_table.lookup(leaf_task.get().name)->get() << " on cpu: " << leaf_task.get().is_on_cpu << std::endl;
+    // }
 
     // Print a tree of Task dependencies
-    std::cerr << "Task tree:" << std::endl;
+    // std::cerr <<"Task tree:" << std::endl;
     {
         // Build parent->children maps
         std::unordered_map<PyObject*, std::vector<PyObject*>> children_map;  // parent -> children
@@ -397,9 +397,7 @@ inline Result<void> ThreadInfo::unwind_tasks()
             auto maybe_name = string_table.lookup(task.name);
             std::string name_str = maybe_name ? maybe_name->get() : "<unknown>";
 
-            std::cerr << prefix << (is_last ? "└── " : "├── ")
-                      << name_str << " (" << task_origin << ")"
-                      << (task.is_on_cpu ? " [ON CPU]" : "") << std::endl;
+            // std::cerr <<prefix << (is_last ? "└── " : "├── ") << name_str << " (" << task_origin << ")" << (task.is_on_cpu ? " [ON CPU]" : "") << std::endl;
 
             auto children_it = children_map.find(task_origin);
             if (children_it != children_map.end()) {
@@ -425,7 +423,7 @@ inline Result<void> ThreadInfo::unwind_tasks()
     bool on_cpu_task_seen = false;
     for (auto& leaf_task : leaf_tasks)
     {
-        std::cerr << "== Unwinding leaf task: " << string_table.lookup(leaf_task.get().name)->get() << std::endl;
+        // std::cerr <<"== Unwinding leaf task: " << string_table.lookup(leaf_task.get().name)->get() << std::endl;
         auto stack_info = std::make_unique<StackInfo>(leaf_task.get().name, leaf_task.get().is_on_cpu);
         on_cpu_task_seen = on_cpu_task_seen || leaf_task.get().is_on_cpu;
 
@@ -433,12 +431,12 @@ inline Result<void> ThreadInfo::unwind_tasks()
         for (auto current_task = leaf_task;;)
         {
             auto& task = current_task.get();
-            std::cerr << "= Unwinding task: " << string_table.lookup(task.name)->get() << " on cpu: " << task.is_on_cpu << std::endl;
+            // std::cerr <<"= Unwinding task: " << string_table.lookup(task.name)->get() << " on cpu: " << task.is_on_cpu << std::endl;
 
             // The task_stack_size includes both the coroutines frames and the "upper" Python synchronous frames
             auto maybe_task_stack_size = task.unwind(stack, task.is_on_cpu ? upper_python_stack_size : unused);
             if (!maybe_task_stack_size) {
-                std::cerr << "SKIPSKIP inconsistent Task " << string_table.lookup(task.name)->get() << std::endl;
+                // std::cerr <<"SKIPSKIP inconsistent Task " << string_table.lookup(task.name)->get() << std::endl;
                 return ErrorKind::TaskInfoError;
             }
 
@@ -451,24 +449,24 @@ inline Result<void> ThreadInfo::unwind_tasks()
                 // subtract the number of Frames in the "upper Python stack" (asyncio machinery + sync entrypoint)
                 // This gives us [outermost coroutine, ... , innermost coroutine, outermost sync function, ... , innermost sync function]
                 size_t frames_to_push = (python_stack.size() > task_stack_size) ? python_stack.size() - task_stack_size : 0;
-                std::cerr << "Task is on CPU, pushing " << frames_to_push << " frames" << std::endl;
+                // std::cerr <<"Task is on CPU, pushing " << frames_to_push << " frames" << std::endl;
                 for (size_t i = 0; i < frames_to_push; i++)
                 {
                     const auto& python_frame = python_stack[frames_to_push - i - 1];
-                    std::cerr << "  " << i << ": " << string_table.lookup(python_frame.get().name)->get() << std::endl;
+                    // std::cerr <<"  " << i << ": " << string_table.lookup(python_frame.get().name)->get() << std::endl;
                     stack.push_front(python_frame);
                 }
             } else {
-                std::cerr << "Task is not on CPU..." << std::endl;
+                // std::cerr <<"Task is not on CPU..." << std::endl;
             }
 
             // Add the task name frame
             stack.push_back(Frame::get(task.name));
-            std::cerr << "Pushed task name frame: " << string_table.lookup(task.name)->get() << std::endl;
+            // std::cerr <<"Pushed task name frame: " << string_table.lookup(task.name)->get() << std::endl;
 
-            std::cerr << "Stack at the end for that Task" << std::endl;
+            // std::cerr <<"Stack at the end for that Task" << std::endl;
             for (size_t i = 0; i < stack.size(); i++) {
-                std::cerr << "  " << i << ": " << string_table.lookup(stack[i].get().name)->get() << std::endl;
+                // std::cerr <<"  " << i << ": " << string_table.lookup(stack[i].get().name)->get() << std::endl;
             }
 
             // Get the next task in the chain
@@ -497,20 +495,20 @@ inline Result<void> ThreadInfo::unwind_tasks()
         // Finish off with the remaining thread stack
         // If we have seen an on-CPU Task, then upper_python_stack_size will be set and will include the sync entry point
         // and the asyncio machinery Frames. Otherwise, we are in `select` (idle) and we should push all the Frames.
-        std::cerr << "Pushing the remaining Thread stack" << std::endl;
+        // std::cerr <<"Pushing the remaining Thread stack" << std::endl;
         // for (size_t i = 0; i < python_stack.size() - (on_cpu_task_seen ? upper_python_stack_size : python_stack.size()); i++) {
         //     const auto& python_frame = python_stack[i];
-        //     std::cerr << "  Skipped: " << i << ": " << string_table.lookup(python_frame.get().name)->get() << std::endl;
+        //     // std::cerr <<"  Skipped: " << i << ": " << string_table.lookup(python_frame.get().name)->get() << std::endl;
         // }
         for (size_t i = python_stack.size() - (on_cpu_task_seen ? upper_python_stack_size : python_stack.size()); i < python_stack.size(); i++) {
             const auto& python_frame = python_stack[i];
-            std::cerr << "  Pushed:  " << i << ": " << string_table.lookup(python_frame.get().name)->get() << std::endl;
+            // std::cerr <<"  Pushed:  " << i << ": " << string_table.lookup(python_frame.get().name)->get() << std::endl;
             stack.push_back(python_frame);
         }
 
-        std::cerr << "Stack after pushing the remaining Thread stack" << std::endl;
+        // std::cerr <<"Stack after pushing the remaining Thread stack" << std::endl;
         for (size_t i = 0; i < stack.size(); i++) {
-            std::cerr << "  " << i << ": " << string_table.lookup(stack[i].get().name)->get() << std::endl;
+            // std::cerr <<"  " << i << ": " << string_table.lookup(stack[i].get().name)->get() << std::endl;
         }
 
         current_tasks.push_back(std::move(stack_info));

--- a/echion/vm.h
+++ b/echion/vm.h
@@ -143,8 +143,7 @@ public:
             instance = VmReader::create(1024 * 1024);  // A megabyte?
             if (!instance)
             {
-                std::cerr << "Failed to initialize VmReader with buffer size " << instance->sz
-                          << std::endl;
+                std::cerr <<"Failed to initialize VmReader with buffer size " << instance->sz << std::endl;
                 return nullptr;
             }
         }
@@ -240,7 +239,7 @@ __attribute__((constructor)) inline void init_safe_copy()
             return;
         }
 
-        std::cerr << "Failed to initialize segv catcher. Using process_vm_readv instead." << std::endl;
+        // std::cerr <<"Failed to initialize segv catcher. Using process_vm_readv instead." << std::endl;
     }
 
     char src[128];
@@ -295,7 +294,7 @@ __attribute__((constructor)) inline void init_safe_copy()
             return;
         }
 
-        std::cerr << "Failed to initialize segv catcher. Using process_vm_readv instead." << std::endl;
+        // std::cerr <<"Failed to initialize segv catcher. Using process_vm_readv instead." << std::endl;
     }
 }
 #endif // if defined PL_DARWIN


### PR DESCRIPTION
## What does this PR do?

https://datadoghq.atlassian.net/browse/PROF-13137

### In short

This depends on
- https://github.com/P403n1x87/echion/pull/198

Note that this PR (unfortunately) doesn't make _all_ our problems go away (as the red CI testifies...)  
There still are issues, just the one that I explained [here](https://datadoghq.atlassian.net/browse/PROF-13137) is gone, as far as I can tell. 

### In depth

The PR aims at reducing the issues caused by race conditions between sampling of CPU Stacks and asyncio Stacks.   
There are three places we can have a race condition. The race condition can happen because the three following events can happen at the same time as the Python thread that runs asyncio Tasks is living its life at the same time we are sampling:

* Sample Python Thread stack (a.k.a. “normal synchronous Stack”)
  * If it’s currently running a Task, it will include (top sync entrypoint) (asyncio runtime) (Runner._step) (coroutine(s)) (sync functions called by coroutines)
  * If it’s not currently running a Task, it will include (top sync entrypoint) (asyncio runtime) (Runner._select)
* Generate TaskInfo/GenInfo objects
  * If it’s currently running a Task/Coroutine, the GenInfo’s will have is_running set to true
  * If it’s not currently running, then it will be false
* Unwind Task Frames
  * If the Task is currently being run, the Frame::read we do in TaskInfo::unwind will show the “upper Python Stack” (sync entrypoint and asyncio runtime) on top of the Task’s Coroutine Frame
  * If the Task is not being run, Frame::read will just show the Task’s Coroutine Frame

If any two of those three Samples are out of sync (one returns “we’re running this Task” and any other one returns “we’re not running this Task”), we are at risk of producing incorrect (and potentially inconsistent) Stacks.

* The case at hand is “Python Stack captures a running state for Task” and then “all GenInfo objects are marked as off-CPU” (this leads to having one Frame of the previously-running Task in an unrelated Task’s Stack)
* We also often witness instances of “GenInfo objects are marked as on-CPU” and then “calling Frame::read doesn’t detect the upper Stack” (this leads to having asynchronous Stacks that do not have their Python entrypoint/asyncio runtime Stacks attached on top)
* … I don’t know if we have instances of the other cases – potentially they’re more stealthy (e.g. something is running but we don’t detect it as such; it makes the result technically incorrect but in a way we can’t easily see) and/or extremely rare for whatever reason

We need a way to either exclude those cases (give up on sampling) or recover from them (I think this will come at a performance cost). In this PR, I implemented the former, which is much easier to do and has no performance cost. We may lose a few samples as a result, but in practice this really rarely happens except upon Task completion.